### PR TITLE
only use the hack with sphinx >= 3.1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,10 @@ templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+# master document
+master_doc = "index"
+suffix = ".rst"
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,20 @@
+name: accessors-rtd
+channels:
+  - conda-forge
+dependencies:
+  - python=3.7
+  - pip
+  - packaging
+  - importlib-metadata
+  - sphinx<2
+  - Pygments=2.3.1
+  - setuptools=41.0.1
+  - docutils=0.14
+  - mock=1.0.1
+  - pillow=5.4.1
+  - commonmark=0.8.1
+  - recommonmark=0.5.0
+  - pip:
+      - alabaster>=0.7,<0.8,!=0.7.5
+      - sphinx-rtd-theme<0.5
+      - readthedocs-sphinx-ext<1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=3.1
 sphinx_rtd_theme
+packaging
 importlib-metadata; python_version < "3.8"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx>3
+sphinx>=3.1
 sphinx_rtd_theme
 importlib-metadata; python_version < "3.8"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=3.1
+sphinx
 sphinx_rtd_theme
 packaging
 importlib-metadata; python_version < "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>=3.1
 isort
 flake8
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=3.1
+sphinx
 packaging
 importlib-metadata; python_version < "3.8"
 isort

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 sphinx>=3.1
+packaging
+importlib-metadata; python_version < "3.8"
 isort
 flake8
 black

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ url = https://github.com/keewis/accessors
 packages = find:
 python_requires = >=3.6
 install_requires =
-    sphinx>3
+    sphinx>=3.1
     importlib-metadata; python_version < "3.8"
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     sphinx>=3.1
+    packaging
     importlib-metadata; python_version < "3.8"
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ url = https://github.com/keewis/accessors
 packages = find:
 python_requires = >=3.6
 install_requires =
-    sphinx>=3.1
+    sphinx
     packaging
     importlib-metadata; python_version < "3.8"
 

--- a/sphinx_autosummary_accessors/__init__.py
+++ b/sphinx_autosummary_accessors/__init__.py
@@ -5,13 +5,21 @@ except ImportError:
 
 import pathlib
 
-from .autosummary import CustomAutosummary
+import packaging.version
+import sphinx
+
 from .documenters import (
     AccessorAttributeDocumenter,
     AccessorCallableDocumenter,
     AccessorDocumenter,
     AccessorMethodDocumenter,
 )
+
+if packaging.version.parse(sphinx.__version__) >= packaging.version.parse("3.1"):
+    from .autosummary import CustomAutosummary
+else:
+    CustomAutosummary = None
+
 
 try:
     __version__ = version("sphinx-autosummary-version")
@@ -29,4 +37,5 @@ def setup(app):
     app.add_autodocumenter(AccessorMethodDocumenter)
     app.add_autodocumenter(AccessorCallableDocumenter)
 
-    app.add_directive("autosummary", CustomAutosummary, override=True)
+    if CustomAutosummary is not None:
+        app.add_directive("autosummary", CustomAutosummary, override=True)


### PR DESCRIPTION
The `autosummary` hack from #6 restricts the sphinx version to `sphinx>=3.1`, but RTD requires `sphinx<2`. This only enables the hack on a sufficient `sphinx` version, so builds using lower versions still pass (the summaries and signatures might be broken, though).