### PR TITLE
add a proper CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,10 @@ jobs:
         sphinx-version: [1.8, 2, 3, "upstream-dev"]
         exclude:
           - python-version: 3.6
-            dependencies: "upstream-dev"
+            sphinx-version: "upstream-dev"
 
           - python-version: 3.7
-            dependencies: "upstream-dev"
+            sphinx-version: "upstream-dev"
 
     steps:
       - name: checkout the repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  linux:
+    name: sphinx
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7]
+        sphinx-version: [1.8, 2, 3]
+        include:
+          - python-version: 3.8
+            dependencies: ""
+
+          - python-version: 3.8
+            dependencies: "upstream-dev"
+
+    steps:
+      - name: checkout the repository
+        uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: install sphinx
+        run: |
+          if [ -n "${{ matrix.dependencies }}" ]; then
+              python -m pip install git+https://github.com/sphinx-doc/sphinx
+          else
+              python -m pip install "sphinx==${{ matrix.sphinx-version }}"
+          fi
+
+      - name: install the extension
+        run: python -m pip install .
+
+      - name: show versions
+        run: python -m pip list
+
+      - name: build the documentation
+        run: |
+          cd docs
+          python -m sphinx -M html -d _build/doctrees -EWT -a . _build/html

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,11 +36,11 @@ jobs:
           if [ -n "${{ matrix.dependencies }}" ]; then
               python -m pip install git+https://github.com/sphinx-doc/sphinx
           else
-              if [ "${{ matrix.sphinx-version }}" -eq "1.8" ]; then
+              if [[ "${{ matrix.sphinx-version }}" == "1.8" ]]; then
                   spec="sphinx==1.8"
-              elif [ "${{ matrix.sphinx-version }}" -eq "2" ]; then
+              elif [[ "${{ matrix.sphinx-version }}" == "2" ]]; then
                   spec="sphinx>=2,<3"
-              elif [ "${{ matrix.sphinx-version }}" -eq "3" ]; then
+              elif [[ "${{ matrix.sphinx-version }}" == "3" ]]; then
                   spec="sphinx>=3,<4"
               fi
               python -m pip install "$spec"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,13 +13,9 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         sphinx-version: [1.8, 2, 3]
         include:
-          - python-version: 3.8
-            sphinx-version: [1.8, 2, 3]
-            dependencies: ""
-
           - python-version: 3.8
             dependencies: "upstream-dev"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         sphinx-version: [1.8, 2, 3]
         include:
           - python-version: 3.8
@@ -39,7 +39,17 @@ jobs:
           if [ -n "${{ matrix.dependencies }}" ]; then
               python -m pip install git+https://github.com/sphinx-doc/sphinx
           else
-              python -m pip install "sphinx==${{ matrix.sphinx-version }}"
+              case "${{ matrix.sphinx-version }}"
+                  1.8)
+                      spec="sphinx==1.8"
+                      ;;
+
+                  2)
+                      spec="sphinx>=2,<3"
+                  3)
+                      spec="sphinx>=3,<4"
+              esac
+              python -m pip install "$spec"
           fi
 
       - name: install other dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,12 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        sphinx-version: [1.8, 2, 3]
-        include:
-          - python-version: 3.8
+        sphinx-version: [1.8, 2, 3, "upstream-dev"]
+        exclude:
+          - python-version: 3.6
+            dependencies: "upstream-dev"
+
+          - python-version: 3.7
             dependencies: "upstream-dev"
 
     steps:
@@ -33,18 +36,16 @@ jobs:
 
       - name: install sphinx
         run: |
-          if [ -n "${{ matrix.dependencies }}" ]; then
-              python -m pip install git+https://github.com/sphinx-doc/sphinx
-          else
-              if [[ "${{ matrix.sphinx-version }}" == "1.8" ]]; then
-                  spec="sphinx==1.8"
-              elif [[ "${{ matrix.sphinx-version }}" == "2" ]]; then
-                  spec="sphinx>=2,<3"
-              elif [[ "${{ matrix.sphinx-version }}" == "3" ]]; then
-                  spec="sphinx>=3,<4"
-              fi
-              python -m pip install "$spec"
+          if [[ "${{ matrix.sphinx-version }}" == "1.8" ]]; then
+              spec="sphinx==1.8"
+          elif [[ "${{ matrix.sphinx-version }}" == "2" ]]; then
+              spec="sphinx>=2,<3"
+          elif [[ "${{ matrix.sphinx-version }}" == "3" ]]; then
+              spec="sphinx>=3,<4"
+          elif [[ "${{ matrix.sphinx-version }}" == "upstream-dev" ]]; then
+              spec="git+https://github.com/sphinx-doc/sphinx"
           fi
+          python -m pip install "$spec"
 
       - name: install other dependencies
         run: python -m pip install -r docs/requirements.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,9 @@ jobs:
               python -m pip install "sphinx==${{ matrix.sphinx-version }}"
           fi
 
+      - name: install other dependencies
+        run: python -m pip install -r requirements.txt
+
       - name: install the extension
         run: python -m pip install .
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: install other dependencies
-        run: python -m pip install -r requirements.txt
+        run: python -m pip install -r docs/requirements.txt
 
       - name: install the extension
         run: python -m pip install .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7]
         sphinx-version: [1.8, 2, 3]
         include:
           - python-version: 3.8
+            sphinx-version: [1.8, 2, 3]
             dependencies: ""
 
           - python-version: 3.8
@@ -39,16 +40,13 @@ jobs:
           if [ -n "${{ matrix.dependencies }}" ]; then
               python -m pip install git+https://github.com/sphinx-doc/sphinx
           else
-              case "${{ matrix.sphinx-version }}"
-                  1.8)
-                      spec="sphinx==1.8"
-                      ;;
-
-                  2)
-                      spec="sphinx>=2,<3"
-                  3)
-                      spec="sphinx>=3,<4"
-              esac
+              if [ "${{ matrix.sphinx-version }}" -eq "1.8" ]; then
+                  spec="sphinx==1.8"
+              elif [ "${{ matrix.sphinx-version }}" -eq "2" ]; then
+                  spec="sphinx>=2,<3"
+              elif [ "${{ matrix.sphinx-version }}" -eq "3" ]; then
+                  spec="sphinx>=3,<4"
+              fi
               python -m pip install "$spec"
           fi
 

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -30,7 +30,7 @@ jobs:
       run: python -m pip list
 
     - name: run isort
-      run: python -m isort -rc --check .
+      run: python -m isort --check .
 
   black:
     name: black

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: linting
 
 on:
   push:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = sphinx_autosummary_accessors
+name = sphinx-autosummary-accessors
 license = MIT
 description = sphinx autosummary extension to properly format pandas or xarray accessors
 long_description_content_type = text/x-rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,9 @@ install_requires =
     packaging
     importlib-metadata; python_version < "3.8"
 
+[options.package_data]
+sphinx_autosummary_accessors = templates/autosummary/*.rst
+
 [flake8]
 ignore =
     # whitespace before ':' - doesn't work well with black

--- a/sphinx_autosummary_accessors/__init__.py
+++ b/sphinx_autosummary_accessors/__init__.py
@@ -22,7 +22,7 @@ else:
 
 
 try:
-    __version__ = version("sphinx-autosummary-version")
+    __version__ = version("sphinx-autosummary-accessors")
 except Exception:
     __version__ = "999"
 


### PR DESCRIPTION
Before, we were only building the example docs using RTD, which doesn't give us more than one sphinx version.

All of this is not unit testing because we're essentially testing the integration in `sphinx` by building a example documentation.